### PR TITLE
Updated AL-Go System Files

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -18,10 +18,10 @@ $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumen
 $webClient.Encoding = [System.Text.Encoding]::UTF8
 Write-Host "Downloading GitHub Helper module"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/AL-Go-Helper.ps1', $ALGoHelperPath)
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -21,10 +21,10 @@ $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumen
 $webClient.Encoding = [System.Text.Encoding]::UTF8
 Write-Host "Downloading GitHub Helper module"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/AL-Go-Helper.ps1', $ALGoHelperPath)
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local
@@ -102,8 +102,8 @@ if (-not $credential) {
 
 if (-not $licenseFileUrl) {
     if ($settings.type -eq "AppSource App") {
-        $description = "When developing AppSource Apps, your local development environment needs the developer licensefile with permissions to your AppSource app object IDs"
-        $default = ""
+        $description = "When developing AppSource Apps for Business Central versions prior to 22, your local development environment needs the developer licensefile with permissions to your AppSource app object IDs"
+        $default = "none"
     }
     else {
         $description = "When developing PTEs, you can optionally specify a developer licensefile with permissions to object IDs of your dependant apps"

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -4,8 +4,8 @@
   "powerPlatformSolutionFolder": "TakeOrder",
   "environments": [
     "andersg (Production)",
-    "UX (Production)", 
-	  "Staging"
+    "UX (Production)",
+    "Staging"
   ],
   "DeployToUX": {
     "environmentName": "production",

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,4 +1,6 @@
-## v3.1
+## Preview
+
+Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
 
 ### Issues
 

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0090"
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v3.1
+        uses: microsoft/AL-Go-Actions/AddExistingApp@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0090"

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -46,14 +46,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -61,7 +61,7 @@ jobs:
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@PPPreview
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,7 +80,7 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -155,14 +155,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v3.1
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -199,14 +199,14 @@ jobs:
           path: '.dependencies'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           project: ${{ matrix.project }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -216,7 +216,7 @@ jobs:
           secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,storageContext,gitHubPackagesContext'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@PPPreview
         id: determineArtifactUrl
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -232,9 +232,10 @@ jobs:
           path: .artifactcache
           key: ${{ steps.determineArtifactUrl.outputs.ArtifactUrl }}
 
-      - name: Run pipeline
+      - name: Build AL Project
         id: RunPipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.1
+        if: matrix.project != env.powerPlatformSolutionFolder
+        uses: microsoft/AL-Go-Actions/RunPipeline@PPPreview
         env:
           BuildMode: ${{ matrix.buildMode }}
         with:
@@ -246,9 +247,22 @@ jobs:
           secretsJson: ${{ env.RepoSecrets }}
           buildMode: ${{ matrix.buildMode }}
 
+      - name: Build PowerPlatform Solution
+        id: BuildPowerPlatform
+        if: matrix.project == env.powerPlatformSolutionFolder && matrix.buildMode == 'default'
+        uses: microsoft/AL-Go-Actions/BuildPowerPlatform@PPPreview
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          solutionFolder: ${{ matrix.project }}
+          outputFolder: ${{ matrix.project }}/.buildartifacts/PowerPlatformSolution/
+          outputFileName: ${{ matrix.project }}
+          appRevision: ${{ env.appRevision }}
+          appBuild: ${{ env.appBuild }}
+
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.1
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@PPPreview
         if: success() || failure()
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -331,10 +345,18 @@ jobs:
           path: '${{ matrix.project }}/bcptTestResults.json'
           if-no-files-found: ignore
 
+      - name: Publish artifacts - Power Platform Solution
+        uses: actions/upload-artifact@v3
+        if: github.ref_name == 'main' || startswith(github.ref_name, 'release/') || needs.Initialization.outputs.deliveryTargetCount > 0 || needs.Initialization.outputs.environmentCount > 0
+        with:
+          name: ${{ env.PowerPlatformSolutionArtifactsName }}
+          path: '${{ matrix.project }}/.buildartifacts/PowerPlatformSolution/'
+          if-no-files-found: ignore
+
       - name: Analyze Test Results
         id: analyzeTestResults
         if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.1
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -342,7 +364,7 @@ jobs:
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.1
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -374,12 +396,12 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -395,10 +417,10 @@ jobs:
           $envName = '${{ steps.envName.outputs.envName }}'
           $deployToSettingStr = [System.Environment]::GetEnvironmentVariable("DeployTo$envName")
           if ($deployToSettingStr) {
-            $deployToSetting = $deployToSettingStr | ConvertFrom-Json
+            $deployToSettings = $deployToSettingStr | ConvertFrom-Json
           }
           else {
-            $deployToSetting = [PSCustomObject]@{}
+            $deployToSettings = [PSCustomObject]@{}
           }
           $authContext = $null
           "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
@@ -413,8 +435,8 @@ jobs:
             Write-Host "::Error::No AuthContext provided"
             exit 1
           }
-          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "EnvironmentName") {
-            $environmentName = $deployToSetting.EnvironmentName
+          if (("$deployToSettings" -ne "") -and $deployToSettings.PSObject.Properties.name -eq "EnvironmentName") {
+            $environmentName = $deployToSettings.environmentName
           }
           else {
             $environmentName = $null
@@ -427,14 +449,14 @@ jobs:
                 }
               }            
             }
-          }
-          if (!($environmentName)) {
-            $environmentName = '${{ steps.envName.outputs.envName }}'
+            if (!($environmentName)) {
+              $environmentName = '${{ steps.envName.outputs.envName }}'
+            }
+            $deployToSettings | Add-Member -MemberType NoteProperty -name 'environmentName' -value $environmentName
           }
           $environmentName = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($environmentName + '${{ matrix.environment }}'.SubString($envName.Length)).ToUpperInvariant()))
-
-          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "projects") {
-            $projects = $deployToSetting.projects
+          if (("$deployToSettings" -ne "") -and $deployToSettings.PSObject.Properties.name -eq "projects") {
+            $projects = $deployToSettings.projects
           }
           else {
             $projects = [System.Environment]::GetEnvironmentVariable("$($envName)-projects")
@@ -444,25 +466,40 @@ jobs:
                 $projects = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('projects')))
               }
             }
+            $deployToSettings | Add-Member -MemberType NoteProperty -Name 'projects' -Value $projects
           }
+          $powerPlatformSolutionFolder = [System.Environment]::GetEnvironmentVariable('PowerPlatformSolutionFolder')
+          $deployPP = $false
           if ($projects -eq '' -or $projects -eq '*') {
             $projects = '*'
+            $deployPP = ("$powerPlatformSolutionFolder" -ne "")
           }
           else {
             $buildProjects = '${{ needs.Initialization.outputs.projects }}' | ConvertFrom-Json
-            $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
+            $projects = ($projects.Split(',') | Where-Object { 
+              $deployALProject = $buildProjects -contains $_
+              if ($_ -eq $powerPlatformSolutionFolder) {
+                $deployPP = $true
+                $deployALProject = $false
+              }
+              $deployALProject
+            }) -join ','
           }
 
           Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
           Write-Host "authContext=$authContext"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "deployTo=$($deployToSettings | ConvertTo-Json -depth 99 -compress)"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
           Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
           Write-Host "environmentName (as Base64)=$environmentName"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
           Write-Host "projects=$projects"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "deployPP=$deployPP"
+          Write-Host "deployPP=$deployPP"
 
-      - name: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v3.1
+      - name: Deploy AL
+        uses: microsoft/AL-Go-Actions/Deploy@PPPreview
+        if: ${{ steps.authContext.outputs.projects }}
         env:
           AuthContext: ${{ steps.authContext.outputs.authContext }}
         with:
@@ -471,6 +508,16 @@ jobs:
           projects: ${{ steps.authContext.outputs.projects }}
           environmentName: ${{ steps.authContext.outputs.environmentName }}
           artifacts: '.artifacts'
+
+      - name: Deploy PowerPlatform
+        if: ${{ steps.authContext.outputs.deployPP == 'true' }}
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@PPPreview
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          artifactPath: '.artifacts'
+          deploySettings: ${{ steps.authContext.outputs.deployTo }} 
+          authSettings: ${{ steps.authContext.outputs.authContext }}
 
   Deliver:
     needs: [ Initialization, Build ]
@@ -491,12 +538,12 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -515,7 +562,7 @@ jobs:
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v3.1
+        uses: microsoft/AL-Go-Actions/Deliver@PPPreview
         env:
           deliveryContext: ${{ steps.deliveryContext.outputs.deliveryContext }}
         with:
@@ -535,7 +582,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0091"

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -48,20 +48,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0092"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v3.1
+        uses: microsoft/AL-Go-Actions/CreateApp@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0092"

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -41,19 +41,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0093"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -76,7 +76,7 @@ jobs:
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v3.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -96,13 +96,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -119,7 +119,7 @@ jobs:
           }
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v3.1
+        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0093"

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -54,13 +54,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0102"
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v3.1
+        uses: microsoft/AL-Go-Actions/CreateApp@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0102"

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -66,14 +66,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0094"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -81,12 +81,12 @@ jobs:
 
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@PPPreview
         with:
           shell: powershell
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v3.1
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -94,6 +94,8 @@ jobs:
 
       - name: Analyze Artifacts
         id: analyzeartifacts
+        env:
+          _appVersion: ${{ github.event.inputs.appVersion }}
         run: |
           $ErrorActionPreference = "STOP"
           Set-StrictMode -version 2.0
@@ -126,17 +128,19 @@ jobs:
             }
             $refname = "$ENV:GITHUB_REF_NAME".Replace('/','_')
             Write-Host "Analyzing artifacts for project $project"
-            $appVersion = '${{ github.event.inputs.appVersion }}'
+            $appVersion = "$ENV:_appVersion"
             if ($appVersion -eq "latest") {
               Write-Host "Grab latest"
-              $artifact = $allArtifacts | Where-Object { $_.name -like "$project-$refname-Apps-*" } | Select-Object -First 1
+              $artifact = $allArtifacts | Where-Object { $_.name -like "$project-$refname-Apps-*" -or $_.name -like "$project-$refname-PowerPlatformSolution-*" } | Select-Object -First 1
             }
             else {
-              Write-Host "Search for $project-$refname-Apps-$appVersion"
-              $artifact = $allArtifacts | Where-Object { $_.name -eq "$project-$refname-Apps-$appVersion" } | Select-Object -First 1
+              Write-Host "Search for $project-$refname-Apps-$appVersion or $project-$refname-PowerPlatformSolution-$appVersion"
+              $artifact = $allArtifacts | Where-Object { $_.name -eq "$project-$refname-Apps-$appVersion" -or $_.name -eq "$project-$refname-PowerPlatformSolution-$appVersion" } | Select-Object -First 1
             }
+
             if ($artifact) {
-              $artifactsVersion = $artifact.name.SubString($artifact.name.LastIndexOf('-Apps-')+6)
+              $startIndex = $artifact.name.LastIndexOf('-') + 1
+              $artifactsVersion = $artifact.name.SubString($startIndex)
             }
             else {
               Write-Host "::Error::No artifacts found for this project"
@@ -152,13 +156,15 @@ jobs:
               $sha = $artifact.workflow_run.head_sha
             }
 
-            $allArtifacts | Where-Object { ($_.name -like "$project-$refname-Apps-$($artifactsVersion)" -or $_.name -like "$project-$refname-TestApps-$($artifactsVersion)" -or $_.name -like "$project-$refname-Dependencies-$($artifactsVersion)") } | ForEach-Object {
+            write-host "looking for $project-$refname-Apps-$artifactsVersion or $project-$refname-TestApps-$artifactsVersion or $project-$refname-Dependencies-$artifactsVersion or $project-$refname-PowerPlatformSolution-$artifactsVersion"
+            $allArtifacts | Where-Object { ($_.name -like "$project-$refname-Apps-$artifactsVersion" -or $_.name -like "$project-$refname-TestApps-$artifactsVersion" -or $_.name -like "$project-$refname-Dependencies-$artifactsVersion" -or $_.name -like "$project-$refname-PowerPlatformSolution-$artifactsVersion") } | ForEach-Object {
               $atype = $_.name.SubString(0,$_.name.Length-$artifactsVersion.Length-1)
               $atype = $atype.SubString($atype.LastIndexOf('-')+1)
               $include += $( [ordered]@{ "name" = $_.name; "url" = $_.archive_download_url; "atype" = $atype; "project" = $thisproject } )
             }
+
             if ($include.Count -eq 0) {
-              Write-Host "::Error::No artifacts found"
+              Write-Host "::Error::No artifacts found for version $artifactsVersion"
               exit 1
             }
           }
@@ -171,7 +177,7 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v3.1
+        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -213,13 +219,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -271,7 +277,7 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v3.1
+        uses: microsoft/AL-Go-Actions/Deliver@PPPreview
         if: ${{ steps.nuGetContext.outputs.nuGetContext }}
         env:
           deliveryContext: ${{ steps.nuGetContext.outputs.nuGetContext }}
@@ -296,7 +302,7 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v3.1
+        uses: microsoft/AL-Go-Actions/Deliver@PPPreview
         if: ${{ steps.storageContext.outputs.storageContext }}
         env:
           deliveryContext: ${{ steps.storageContext.outputs.storageContext }}
@@ -334,7 +340,7 @@ jobs:
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v3.1
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
@@ -351,7 +357,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0094"

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -50,13 +50,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0095"
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v3.1
+        uses: microsoft/AL-Go-Actions/CreateApp@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0095"

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -34,21 +34,21 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0101"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@PPPreview
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -82,14 +82,14 @@ jobs:
           path: '${{ github.workspace }}\.dependencies'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           project: ${{ matrix.project }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -99,7 +99,7 @@ jobs:
           secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@PPPreview
         id: determineArtifactUrl
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -109,7 +109,7 @@ jobs:
           secretsJson: ${{ env.RepoSecrets }}
 
       - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.1
+        uses: microsoft/AL-Go-Actions/RunPipeline@PPPreview
         env:
           BuildMode: ${{ matrix.buildMode }}
         with:
@@ -123,7 +123,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.1
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@PPPreview
         if: success() || failure()
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -186,7 +186,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.1
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.1
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0101"

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0096"
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v3.1
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -54,7 +54,7 @@ jobs:
   
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0096"

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -34,21 +34,21 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0099"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@PPPreview
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -82,14 +82,14 @@ jobs:
           path: '${{ github.workspace }}\.dependencies'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           project: ${{ matrix.project }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -99,7 +99,7 @@ jobs:
           secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@PPPreview
         id: determineArtifactUrl
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -109,7 +109,7 @@ jobs:
           secretsJson: ${{ env.RepoSecrets }}
 
       - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.1
+        uses: microsoft/AL-Go-Actions/RunPipeline@PPPreview
         env:
           BuildMode: ${{ matrix.buildMode }}
         with:
@@ -123,7 +123,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.1
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@PPPreview
         if: success() || failure()
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -186,7 +186,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.1
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.1
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0099"

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -34,21 +34,21 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0100"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@PPPreview
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -82,14 +82,14 @@ jobs:
           path: '${{ github.workspace }}\.dependencies'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           project: ${{ matrix.project }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -99,7 +99,7 @@ jobs:
           secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@PPPreview
         id: determineArtifactUrl
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -109,7 +109,7 @@ jobs:
           secretsJson: ${{ env.RepoSecrets }}
 
       - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.1
+        uses: microsoft/AL-Go-Actions/RunPipeline@PPPreview
         env:
           BuildMode: ${{ matrix.buildMode }}
         with:
@@ -123,7 +123,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.1
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@PPPreview
         if: success() || failure()
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -186,7 +186,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.1
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.1
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0100"

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -39,14 +39,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0097"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -63,7 +63,7 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         if: steps.ReadSettings.outputs.UnknownEnvironment == 1
         env:
           secrets: ${{ toJson(secrets) }}
@@ -97,7 +97,7 @@ jobs:
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v3.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -129,12 +129,12 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -142,91 +142,41 @@ jobs:
           settingsJson: ${{ env.Settings }}
           secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
-      - name: AuthContext
-        id: authContext
-        run: |
-          $ErrorActionPreference = "STOP"
-          Set-StrictMode -version 2.0
-          $envName = '${{ steps.envName.outputs.envName }}'
-          $deployToSettingStr = [System.Environment]::GetEnvironmentVariable("DeployTo$envName")
-          if ($deployToSettingStr) {
-            $deployToSetting = $deployToSettingStr | ConvertFrom-Json
-          }
-          else {
-            $deployToSetting = [PSCustomObject]@{}
-          }
-          $authContext = $null
-          if ($env:deviceCode) {
-            $authContext = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
-          }
-          "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
-            if (!($authContext)) {
-              $authContext = [System.Environment]::GetEnvironmentVariable($_)
-              if ($authContext) {
-                Write-Host "Using $_ secret as AuthContext"
-              }
-            }            
-          }
-          if (!($authContext)) {
-            Write-Host "::Error::No AuthContext provided"
-            exit 1
-          }
-          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "EnvironmentName") {
-            $environmentName = $deployToSetting.EnvironmentName
-          }
-          else {
-            $environmentName = $null
-            "$($envName)-EnvironmentName", "$($envName)_EnvironmentName", "EnvironmentName" | ForEach-Object {
-              if (!($EnvironmentName)) {
-                $EnvironmentName = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable($_)))
-                if ($EnvironmentName) {
-                  Write-Host "Using $_ secret as EnvironmentName"
-                  Write-Host "Please consider using the DeployTo$_ setting instead, where you can specify EnvironmentName, projects and branches"
-                }
-              }            
-            }
-          }
-          if (!($environmentName)) {
-            $environmentName = '${{ steps.envName.outputs.envName }}'
-          }
-          $environmentName = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($environmentName + '${{ matrix.environment }}'.SubString($envName.Length)).ToUpperInvariant()))
-          if (("$deployToSetting" -ne "") -and $deployToSetting.PSObject.Properties.name -eq "projects") {
-            $projects = $deployToSetting.projects
-          }
-          else {
-            $projects = [System.Environment]::GetEnvironmentVariable("$($envName)-projects")
-            if (-not $projects) {
-              $projects = [System.Environment]::GetEnvironmentVariable("$($envName)_Projects")
-              if (-not $projects) {
-                $projects = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String([System.Environment]::GetEnvironmentVariable('projects')))
-              }
-            }
-          }
-          if ($projects -eq '') {
-            $projects = '*'
-          }
-          elseif ($projects -ne '*') {
-            $buildProjects = '${{ needs.Initialization.outputs.projects }}' | ConvertFrom-Json
-            $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
-          }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
-          Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
-          Write-Host "environmentName (as Base64)=$environmentName"
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "projects=$projects"
-          Write-Host "projects=$projects"
+      - name: Get Auth context
+        uses: microsoft/AL-Go-Actions/ReadAuthContext@PPPreview
+        with: 
+          shell: powershell
+          envName: ${{ steps.envName.outputs.envName }}
+          environment: ${{ steps.envName.outputs.envName }}
 
-      - name: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v3.1
+      - name: Deploy AL
+        uses: microsoft/AL-Go-Actions/Deploy@PPPreview
         env:
-          AuthContext: ${{ steps.authContext.outputs.authContext }}
+          AuthContext: ${{ env.authContext }}
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           type: 'Publish'
-          projects: ${{ steps.authContext.outputs.projects }}
-          environmentName: ${{ steps.authContext.outputs.environmentName }}
+          projects: ${{ env.projects }}
+          environmentName: ${{ env.environmentName }}
           artifacts: ${{ github.event.inputs.appVersion }}
+
+      - name: Get Artifacts
+        uses: microsoft/AL-Go-Actions/GetArtifacts@PPPreview
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          artifactVersion: ${{ github.event.inputs.appVersion }}
+
+      - name: Deploy PowerPlatform
+        if: ${{ env.deployPP == 'true' }}
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@PPPreview
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          artifactPath: '.artifacts'
+          deploySettings: ${{ env.deployTo }} 
+          authSettings: ${{ env.authContext }}
 
   PostProcess:
     if: always()
@@ -238,7 +188,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0097"

--- a/.github/workflows/PullPowerPlatformChanges.yaml
+++ b/.github/workflows/PullPowerPlatformChanges.yaml
@@ -1,0 +1,104 @@
+name: " Pull Power Platform changes"
+
+on:
+  workflow_dispatch:
+    inputs:
+      solutionName:
+        description: "Name of the Power Platform solution. (* takes the name from Al-go-settings.json)"
+        required: true
+        default: "*"
+      environment:
+        description: "Environment"
+        required: true
+        default: "Staging"
+      directCommit:
+        description: Direct COMMIT (Y/N)
+        required: false
+        default: "N"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  PullChanges:
+    runs-on: [windows-latest]
+    name: Pull changes from ${{ inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize the workflow
+        id: init
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
+        with:
+          shell: powershell
+          eventId: "DO0103"
+
+      - name: EnvName
+        id: envName
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
+          $envName = '${{ inputs.environment }}'
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
+        with:
+          shell: powershell
+
+      - name: Read secrets
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          settingsJson: ${{ env.Settings }}
+          secrets: "${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects"
+      
+      - name: read auth context
+        id: authContext
+        uses: microsoft/AL-Go-Actions/ReadAuthContext@PPPreview
+        with:
+          shell: powershell
+          envName: ${{ steps.envName.outputs.envName }}
+          environment: ${{ steps.envName.outputs.envName }}
+
+      - name: Set Power Platform solution name
+        id: solutionName
+        shell: powershell
+        env: 
+          _inputSolutionName: ${{ inputs.solutionName }}
+        run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
+          $solutionName = $env:_inputSolutionName
+          if ($solutionName -eq "*") {
+            write-host "Solution name is not provided. Taking the name from Al-go-settings.json"
+            $solutionName = $env:powerPlatformSolutionFolder
+          }
+          write-host "Solution name: $solutionName"
+          Add-Content -Path $env:GITHUB_ENV -Value "powerPlatformSolutionFolder=$solutionName"   
+
+      - name: Export changes from Power Platform 
+        uses: microsoft/AL-Go-Actions/PullPowerPlatformChanges@PPPreview
+        with: 
+          shell: powershell
+          solutionName: ${{ env.powerPlatformSolutionFolder }}
+          directCommit: ${{ inputs.directCommit == 'Y' }}
+          deploySettings: ${{ env.deployTo }} 
+          authSettings: ${{ env.authContext }}
+
+      - name: Finalize the workflow
+        if: always()
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
+        with:
+          shell: powershell
+          eventId: "DO0103"
+          telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -34,7 +34,7 @@ jobs:
           lfs: true
           ref: refs/pull/${{ github.event.number }}/merge
 
-      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v3.1
+      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@PPPreview
         with:
           baseSHA: ${{ github.event.pull_request.base.sha }}
           headSHA: ${{ github.event.pull_request.head.sha }}
@@ -61,14 +61,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0104"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -76,7 +76,7 @@ jobs:
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@PPPreview
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -113,14 +113,14 @@ jobs:
           path: '.dependencies'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           project: ${{ matrix.project }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -130,7 +130,7 @@ jobs:
           secrets: 'licenseFileUrl,insiderSasToken,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
 
       - name: Determine ArtifactUrl
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v3.1
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@PPPreview
         id: determineArtifactUrl
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -148,7 +148,7 @@ jobs:
 
       - name: Run pipeline
         id: RunPipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.1
+        uses: microsoft/AL-Go-Actions/RunPipeline@PPPreview
         env:
           BuildMode: ${{ matrix.buildMode }}
         with:
@@ -162,7 +162,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.1
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@PPPreview
         if: success() || failure()
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
@@ -224,7 +224,7 @@ jobs:
       - name: Analyze Test Results
         id: analyzeTestResults
         if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.1
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -232,7 +232,7 @@ jobs:
 
       - name: Cleanup
         if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.1
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@PPPreview
         with:
           shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -251,7 +251,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0104"

--- a/.github/workflows/PushPowerPlatformChanges.yaml
+++ b/.github/workflows/PushPowerPlatformChanges.yaml
@@ -1,0 +1,120 @@
+name: " Push Power Platform changes"
+
+on:
+  workflow_dispatch:
+    inputs:
+      solutionName:
+        description: "Name of the Power Platform solution. (* takes the name from Al-go-settings.json)"
+        required: true
+        default: "*"
+      environment:
+        description: "Environment"
+        required: true
+        default: "Staging"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  PushChanges:
+    runs-on: [windows-latest]
+    name: Push changes to ${{ inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize the workflow
+        id: init
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
+        with:
+          shell: powershell
+          eventId: "DO0103"
+
+      - name: EnvName
+        id: envName
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
+          $envName = '${{ inputs.environment }}'
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
+        with:
+          shell: powershell
+
+      - name: Read secrets
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          settingsJson: ${{ env.Settings }}
+          secrets: "${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects"
+
+      - name: read auth context
+        id: authContext
+        uses: microsoft/AL-Go-Actions/ReadAuthContext@PPPreview
+        with:
+          shell: powershell
+          envName: ${{ steps.envName.outputs.envName }}
+          environment: ${{ steps.envName.outputs.envName }}
+
+      - name: Set Power Platform solution name
+        id: solutionName
+        shell: powershell
+        env:
+          _inputSolutionName: ${{ inputs.solutionName }}
+        run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
+          $solutionName = $env:_inputSolutionName
+          if ($solutionName -eq "*") {
+            write-host "Solution name is not provided. Taking the name from Al-go-settings.json"
+            $solutionName = $env:powerPlatformSolutionFolder
+          }
+          write-host "Solution name: $solutionName"
+          Add-Content -Path $env:GITHUB_ENV -Value "powerPlatformSolutionFolder=$solutionName"
+
+      - name: Parse DeployToSettings and AuthContext
+        uses: microsoft/AL-Go-Actions/ReadPowerPlatformSettings@PPPreview
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          deploySettings: ${{ env.deployTo }} 
+          authSettings: ${{ env.authContext }}
+
+      - name: Build PowerPlatform Solution
+        id: BuildPowerPlatform
+        uses: microsoft/AL-Go-Actions/BuildPowerPlatform@PPPreview
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          solutionFolder: ${{ env.powerPlatformSolutionFolder }}
+          outputFolder: .buildartifacts/PowerPlatformSolution/
+          outputFileName: tempsolution-PowerPlatformSolution-
+          environmentName: ${{ env.environmentName }}
+          companyId: ${{ env.companyId }}
+      
+      - name: Export and push changes to Power Platform
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@PPPreview
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+          artifactPath: '.buildartifacts'
+          deploySettings: ${{ env.deployTo }} 
+          authSettings: ${{ env.authContext }}
+
+      - name: Finalize the workflow
+        if: always()
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
+        with:
+          shell: powershell
+          eventId: "DO0103"
+          telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       templateUrl:
-        description: Template Repository URL (current is https://github.com/microsoft/AL-Go-PTE@main)
+        description: Template Repository URL (current is https://github.com/microsoft/AL-Go-PTE@PPPreview)
         required: false
         default: ''
       directCommit:
@@ -32,20 +32,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@PPPreview
         with:
           shell: powershell
           eventId: "DO0098"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName,templateUrl
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@PPPreview
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -82,7 +82,7 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v3.1
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@PPPreview
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@PPPreview
         with:
           shell: powershell
           eventId: "DO0098"

--- a/ALApp/.AL-Go/cloudDevEnv.ps1
+++ b/ALApp/.AL-Go/cloudDevEnv.ps1
@@ -18,10 +18,10 @@ $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumen
 $webClient.Encoding = [System.Text.Encoding]::UTF8
 Write-Host "Downloading GitHub Helper module"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/PowerPlatform/Github-Helper.psm1', $GitHubHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/PowerPlatform/AL-Go-Helper.ps1', $ALGoHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/AL-Go-Helper.ps1', $ALGoHelperPath)
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/ALApp/.AL-Go/localDevEnv.ps1
+++ b/ALApp/.AL-Go/localDevEnv.ps1
@@ -21,10 +21,10 @@ $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumen
 $webClient.Encoding = [System.Text.Encoding]::UTF8
 Write-Host "Downloading GitHub Helper module"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/PowerPlatform/Github-Helper.psm1', $GitHubHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/BusinessCentralDemos/AL-Go-Actions/PowerPlatform/AL-Go-Helper.ps1', $ALGoHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/PPPreview/AL-Go-Helper.ps1', $ALGoHelperPath)
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local
@@ -102,8 +102,8 @@ if (-not $credential) {
 
 if (-not $licenseFileUrl) {
     if ($settings.type -eq "AppSource App") {
-        $description = "When developing AppSource Apps, your local development environment needs the developer licensefile with permissions to your AppSource app object IDs"
-        $default = ""
+        $description = "When developing AppSource Apps for Business Central versions prior to 22, your local development environment needs the developer licensefile with permissions to your AppSource app object IDs"
+        $default = "none"
     }
     else {
         $description = "When developing PTEs, you can optionally specify a developer licensefile with permissions to object IDs of your dependant apps"
@@ -117,10 +117,10 @@ if (-not $licenseFileUrl) {
         -default $default `
         -doNotConvertToLower `
         -trimCharacters @('"',"'",' ')
+}
 
-    if ($licenseFileUrl -eq "none") {
-        $licenseFileUrl = ""
-    }
+if ($licenseFileUrl -eq "none") {
+    $licenseFileUrl = ""
 }
 
 CreateDevEnv `


### PR DESCRIPTION
## Preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

### Issues

Issue #446 Wrong NewLine character in Release Notes
Issue #453 DeliverToStorage - override fails reading secrets
Issue #434 Use gh auth token to get authentication token instead of gh auth status
Issue #501 The Create New App action will now use 22.0.0.0 as default application reference and include NoImplicitwith feature.


### New behavior

The following workflows:

- Create New App
- Create New Test App
- Create New Performance Test App
- Increment Version Number
- Add Existing App
- Create Online Development Environment

All these actions now uses the selected branch in the **Run workflow** dialog as the target for the Pull Request or Direct COMMIT.

### New Settings

- `UseCompilerFolder`: Setting useCompilerFolder to true causes your pipelines to use containerless compiling. Unless you also set `doNotPublishApps` to true, setting useCompilerFolder to true won't give you any performance advantage, since AL-Go for GitHub will still need to create a container in order to publish and test the apps. In the future, publishing and testing will be split from building and there will be other options for getting an instance of Business Central for publishing and testing. 
- `vsixFile`: vsixFile should be a direct download URL to the version of the AL Language extension you want to use for building the project or repo. By default, AL-Go will use the AL Language extension that comes with the Business Central Artifacts.

### New Actions

- **DetermineArtifactUrl** is used to determine which artifacts to use for building a project in CI/CD, PullRequestHandler, Current, NextMinor and NextMajor workflows.

### License File

With the changes to the CRONUS license in Business Central version 22, that license can in most cases be used as a developer license for AppSource Apps and it is no longer mandatory to specify a license file in AppSource App repositories.
Obviously, if you build and test your app for Business Central versions prior to 21, it will fail if you don't specify a licenseFileUrl secret.
